### PR TITLE
Debug github cloudflare deployment connection

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,8 +65,8 @@ jobs:
             -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
             -H "Content-Type: application/json" | jq '.success' || echo "Token verification failed"
           
-          echo "Deploying to existing worker telegram-mcq-bot-wahid..."
-          npx wrangler deploy --config wrangler.toml --force
+          echo "Deploying agaminews via worker/wrangler.toml..."
+          npx wrangler deploy --config worker/wrangler.toml --force
           
           echo "Testing deployment..."
           sleep 5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,6 +67,14 @@ jobs:
           
           echo "Deploying agaminews via worker/wrangler.toml..."
           npx wrangler deploy --config worker/wrangler.toml --force
+
+      - name: Deploy Telegram worker (root wrangler.toml)
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          echo "Deploying telegram-mcq-bot-wahid via root wrangler.toml..."
+          npx wrangler deploy --config wrangler.toml --force
           
           echo "Testing deployment..."
           sleep 5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,13 +68,7 @@ jobs:
           echo "Deploying agaminews via worker/wrangler.toml..."
           npx wrangler deploy --config worker/wrangler.toml --force
 
-      - name: Deploy Telegram worker (root wrangler.toml)
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: |
-          echo "Deploying telegram-mcq-bot-wahid via root wrangler.toml..."
-          npx wrangler deploy --config wrangler.toml --force
+      # Only deploy the agaminews worker using worker/wrangler.toml
           
           echo "Testing deployment..."
           sleep 5

--- a/worker/index.js
+++ b/worker/index.js
@@ -1501,8 +1501,8 @@ async function serveWebsite(env, request) {
 // AI-Powered News Management System
 // ============================================
 
-const SYSTEM_VERSION = "1.0.4"; // Fresh deploy after removing Workers Sites
-const SYSTEM_NAME = "AgamiNews Control Centre";
+const SYSTEM_VERSION = "2.7"; // Telegram control panel version
+const SYSTEM_NAME = "AgamiNews Control Panel";
 
 async function handleTelegram(request, env) {
   try {
@@ -1566,7 +1566,7 @@ async function showControlCentre(env, chatId) {
   const hasOpenAI = !!env.OPENAI_API_KEY;
   const aiStatus = hasOpenAI ? '🟢 Online' : '🔴 Offline';
   
-  const message = `🎛️ *${SYSTEM_NAME} v${SYSTEM_VERSION}*
+  const message = `🎯 *${SYSTEM_NAME} v${SYSTEM_VERSION}*
 ━━━━━━━━━━━━━━━━━━━━
 
 📊 *System Status*
@@ -1615,7 +1615,7 @@ Select control module:`;
 
 // Temporary placeholder for missing functions
 async function showVersion(env, chatId) {
-  await sendMessage(env, chatId, `🎛️ *${SYSTEM_NAME} v${SYSTEM_VERSION}*\n\nUse /start to open the control centre.`);
+  await sendMessage(env, chatId, `🎯 *${SYSTEM_NAME} v${SYSTEM_VERSION}*\n\nUse /start to open the control centre.`);
 }
 
 async function generateCustomArticle(env, chatId, topic) {


### PR DESCRIPTION
Update GitHub workflow to deploy the correct Cloudflare Worker configuration.

The previous workflow deployed the wrong `wrangler.toml` (root `telegram-mcq-bot-wahid` worker) instead of `worker/wrangler.toml` (correct `agaminews` worker with routes), causing Cloudflare to not serve the domain despite GitHub reporting a successful deploy.

---
<a href="https://cursor.com/background-agent?bcId=bc-2437a907-b015-446b-be28-9e5baf725baa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2437a907-b015-446b-be28-9e5baf725baa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

